### PR TITLE
Support building EL8 on EL7

### DIFF
--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -30,6 +30,7 @@ srpm: build_prepare
 	/usr/bin/mock \
 		--no-cleanup-after \
 		-r $(MOCK_CONFIG) \
+		--bootstrap-chroot \
 		--define "__version $(VERSION)$(VERSION_SUFFIX)" \
 		--define "__release $(BUILD_NUMBER)" \
 		--resultdir=$(RESULT_DIR) \
@@ -42,6 +43,7 @@ rpm: srpm
 	/usr/bin/mock \
 		--no-cleanup-after \
 		-r $(MOCK_CONFIG) \
+		--bootstrap-chroot \
 		--define "__version $(VERSION)$(VERSION_SUFFIX)"\
 		--define "__release $(BUILD_NUMBER)"\
 		--resultdir=$(RESULT_DIR) \


### PR DESCRIPTION
To summarize we encounter this issue: https://github.com/rpm-software-management/mock/wiki/FAQ#i-cannot-build-fedora-or-rhel8-beta-package-on-rhelcentos-7

When trying to build EL8 packages on EL7 (Our CentOS-7 package builder). Adding this switch allows mock to self bootstrap an EL8 mock chroot to install EL8 packages. 

I tested this out on our CentOS-7 builder.