### PR TITLE
Revert "Support building EL8 on EL7"

### DIFF
--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -30,7 +30,6 @@ srpm: build_prepare
 	/usr/bin/mock \
 		--no-cleanup-after \
 		-r $(MOCK_CONFIG) \
-		--bootstrap-chroot \
 		--define "__version $(VERSION)$(VERSION_SUFFIX)" \
 		--define "__release $(BUILD_NUMBER)" \
 		--resultdir=$(RESULT_DIR) \
@@ -43,7 +42,6 @@ rpm: srpm
 	/usr/bin/mock \
 		--no-cleanup-after \
 		-r $(MOCK_CONFIG) \
-		--bootstrap-chroot \
 		--define "__version $(VERSION)$(VERSION_SUFFIX)"\
 		--define "__release $(BUILD_NUMBER)"\
 		--resultdir=$(RESULT_DIR) \


### PR DESCRIPTION
Reverts confluentinc/avro-c-packaging#3

THis is breaking package builds because the various mock versions we have aren't supported on the various images we use (ie 3.2.x -> Fedora23):

```
09:17:10  rm -f pkgs-1.8.0_confluent6.0.0-0.1.SNAPSHOT-epel-6-x86_64/avro-c*.rpm
09:17:10  /usr/bin/mock \
09:17:10  	--no-cleanup-after \
09:17:10  	-r epel-6-x86_64 \
09:17:10  	--bootstrap-chroot \
09:17:10  	--define "__version 1.8.0_confluent6.0.0" \
09:17:10  	--define "__release 0.1.SNAPSHOT" \
09:17:10  	--resultdir=pkgs-1.8.0_confluent6.0.0-0.1.SNAPSHOT-epel-6-x86_64 \
09:17:10  	--buildsrpm \
09:17:10  	--spec=avro-c.spec \
09:17:10  	--sources=SOURCES
09:17:10  Usage: mock [options]
09:17:10  
09:17:10  mock: error: no such option: --bootstrap-chroot
09:17:10  make: *** [srpm] Error 2
```

So I'm reverting here and going to re-send a PR that has an environment override.