### PR TITLE
Add override option to rpm make

### DIFF
--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -28,6 +28,7 @@ build_prepare: archive
 
 srpm: build_prepare
 	/usr/bin/mock \
+		$(MOCK_OPTIONS) \
 		--no-cleanup-after \
 		-r $(MOCK_CONFIG) \
 		--define "__version $(VERSION)$(VERSION_SUFFIX)" \
@@ -40,6 +41,7 @@ srpm: build_prepare
 
 rpm: srpm
 	/usr/bin/mock \
+		$(MOCK_OPTIONS) \
 		--no-cleanup-after \
 		-r $(MOCK_CONFIG) \
 		--define "__version $(VERSION)$(VERSION_SUFFIX)"\

--- a/rpm/README
+++ b/rpm/README
@@ -9,3 +9,8 @@ Build:
 
    MOCK_CONFIG=fedora-20-x86_64 make
 
+Additional Mock Options:
+
+    # Say you wanted to build an RPM targeting a distro with rpm>4.12.x with rpm<4.12.x
+    MOCK_OPTIONS=--bootstrap-chroot MOCK_CONFIG=fedora-30-x86_64 make
+


### PR DESCRIPTION
Better implementation of https://github.com/confluentinc/avro-c-packaging/pull/3

We can now override mock options:

Without specifying (expected fails as C7 needs `--boostrap-chroot`):
```
[root@ip-172-31-35-84 rpm]# make MOCK_CONFIG=epel-8-x86_64
cd ../ && \
git archive --prefix=avro-c-1.8.0/ \
  -o rpm/SOURCES/avro-c-1.8.0.tar.gz HEAD
cp ../debian/patches/*.patch SOURCES
mkdir -p pkgs-1.8.0-1-epel-8-x86_64
rm -f pkgs-1.8.0-1-epel-8-x86_64/avro-c*.rpm
/usr/bin/mock \
	 \
	--no-cleanup-after \
	-r epel-8-x86_64 \
	--define "__version 1.8.0" \
	--define "__release 1" \
	--resultdir=pkgs-1.8.0-1-epel-8-x86_64 \
	--buildsrpm \
	--spec=avro-c.spec \
	--sources=SOURCES
INFO: mock.py version 1.4.21 starting (python version = 3.6.8)...
...
Total                                                                                                                       29 MB/s |  10 MB  00:00:00
Running transaction check
Running transaction test
Transaction test succeeded
Running transaction


Invalid version flag: if

make: *** [rpm] Error 30
```

Now with an override (`--bootstrap-chroot` so it can build EL8 on EL7):

```
[root@ip-172-31-35-84 rpm]# make MOCK_CONFIG=epel-8-x86_64 MOCK_OPTIONS=--bootstrap-chroot
cd ../ && \
git archive --prefix=avro-c-1.8.0/ \
  -o rpm/SOURCES/avro-c-1.8.0.tar.gz HEAD
cp ../debian/patches/*.patch SOURCES
mkdir -p pkgs-1.8.0-1-epel-8-x86_64
rm -f pkgs-1.8.0-1-epel-8-x86_64/avro-c*.rpm
/usr/bin/mock \
	--bootstrap-chroot \
	--no-cleanup-after \
	-r epel-8-x86_64 \
	--define "__version 1.8.0" \
	--define "__release 1" \
	--resultdir=pkgs-1.8.0-1-epel-8-x86_64 \
	--buildsrpm \
	--spec=avro-c.spec \
	--sources=SOURCES
INFO: mock.py version 1.4.21 starting (python version = 3.6.8)...
...
Wrote: /builddir/build/RPMS/avro-c-1.8.0-1.el8.x86_64.rpm
Wrote: /builddir/build/RPMS/avro-c-devel-1.8.0-1.el8.x86_64.rpm
Wrote: /builddir/build/RPMS/avro-c-tools-1.8.0-1.el8.x86_64.rpm
Wrote: /builddir/build/RPMS/avro-c-debugsource-1.8.0-1.el8.x86_64.rpm
Wrote: /builddir/build/RPMS/avro-c-debuginfo-1.8.0-1.el8.x86_64.rpm
Wrote: /builddir/build/RPMS/avro-c-tools-debuginfo-1.8.0-1.el8.x86_64.rpm
Executing(%clean): /bin/sh -e /var/tmp/rpm-tmp.275vUS
+ umask 022
+ cd /builddir/build/BUILD
+ cd avro-c-1.8.0
+ rm -rf /builddir/build/BUILDROOT/avro-c-1.8.0-1.el8.x86_64
+ exit 0
Finish: rpmbuild avro-c-1.8.0-1.el8.src.rpm
Finish: build phase for avro-c-1.8.0-1.el8.src.rpm
INFO: Done(pkgs-1.8.0-1-epel-8-x86_64/avro-c-1.8.0-1.el8.src.rpm) Config(epel-8-x86_64) 0 minutes 52 seconds
INFO: Results and/or logs in: pkgs-1.8.0-1-epel-8-x86_64
Finish: run
======= Binary RPMs now available in pkgs-1.8.0-1-epel-8-x86_64 =======
```