### PR TITLE
Fix AutoReq pkgconfig(libsnappy) bug

### DIFF
--- a/rpm/avro-c.spec
+++ b/rpm/avro-c.spec
@@ -15,6 +15,14 @@ BuildRequires: cmake zlib-devel snappy-devel jansson-devel
 #BuildRequires: lzma-devel
 BuildRoot: %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 
+# Something odd happens with AutoReq.
+# snappy-devel provides 'pkgconfig(snappy)', but for some reason
+# AutoReq picks up 'pkgconfig(libsnappy)' so we insert a hack here
+# to change it to the right Req
+%filter_from_requires s/pkgconfig(libsnappy)/pkgconfig(snappy)/g
+# After defining the filter, we need to call this to set it up
+%filter_setup
+
 %description
 Apache Avro™ is a data serialization system.
 Avro provides:


### PR DESCRIPTION
For some reason AutoReq picks up `pkgconfig(libsnappy)` instead of the actual
advertised `pkgconfig(snappy)` from snappy-devel - so using some very obscure RPM features, we fix the AutoReq.