### PR TITLE
Collapse rpm branch into master

### DIFF
--- a/SOURCES/0001-Use-GNUInstallDirs-for-proper-install-locations.patch
+++ b/SOURCES/0001-Use-GNUInstallDirs-for-proper-install-locations.patch
@@ -1,0 +1,1 @@
+../debian/patches/0001-Use-GNUInstallDirs-for-proper-install-locations.patch

--- a/rpm/.gitignore
+++ b/rpm/.gitignore
@@ -1,0 +1,2 @@
+pkgs-*
+SOURCES

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -1,0 +1,56 @@
+PACKAGE_NAME?=	avro-c
+VERSION?=	1.8.0
+VERSION_SUFFIX?=
+
+BUILD_NUMBER?= 1
+
+MOCK_CONFIG?=default
+
+RESULT_DIR?=pkgs-$(VERSION)$(VERSION_SUFFIX)-$(BUILD_NUMBER)-$(MOCK_CONFIG)
+
+all: rpm
+
+
+SOURCES:
+	mkdir -p SOURCES
+
+archive: SOURCES
+	cd ../ && \
+	git archive --prefix=$(PACKAGE_NAME)-$(VERSION)$(VERSION_SUFFIX)/ \
+	  -o rpm/SOURCES/$(PACKAGE_NAME)-$(VERSION)$(VERSION_SUFFIX).tar.gz HEAD
+
+
+build_prepare: archive
+	cp ../debian/patches/*.patch SOURCES
+	mkdir -p $(RESULT_DIR)
+	rm -f $(RESULT_DIR)/$(PACKAGE_NAME)*.rpm
+
+
+srpm: build_prepare
+	/usr/bin/mock \
+		$(MOCK_OPTIONS) \
+		--no-cleanup-after \
+		-r $(MOCK_CONFIG) \
+		--define "__version $(VERSION)$(VERSION_SUFFIX)" \
+		--define "__release $(BUILD_NUMBER)" \
+		--resultdir=$(RESULT_DIR) \
+		--buildsrpm \
+		--spec=$(PACKAGE_NAME).spec \
+		--sources=SOURCES
+	@echo "======= Source RPM now available in $(RESULT_DIR) ======="
+
+rpm: srpm
+	/usr/bin/mock \
+		$(MOCK_OPTIONS) \
+		--no-cleanup-after \
+		-r $(MOCK_CONFIG) \
+		--define "__version $(VERSION)$(VERSION_SUFFIX)"\
+		--define "__release $(BUILD_NUMBER)"\
+		--resultdir=$(RESULT_DIR) \
+		--rebuild $(RESULT_DIR)/$(PACKAGE_NAME)*.src.rpm
+	@echo "======= Binary RPMs now available in $(RESULT_DIR) ======="
+
+clean:
+	rm -rf SOURCES
+
+distclean: clean

--- a/rpm/README
+++ b/rpm/README
@@ -1,0 +1,16 @@
+
+Build RPM packages
+==================
+
+Requires: mock
+
+
+Build:
+
+   MOCK_CONFIG=fedora-20-x86_64 make
+
+Additional Mock Options:
+
+    # Say you wanted to build an RPM targeting a distro with rpm>4.12.x with rpm<4.12.x
+    MOCK_OPTIONS=--bootstrap-chroot MOCK_CONFIG=fedora-30-x86_64 make
+

--- a/rpm/avro-c.spec
+++ b/rpm/avro-c.spec
@@ -80,6 +80,7 @@ make %{?_smp_mflags}
 %install
 rm -rf %{buildroot}
 DESTDIR=%{buildroot} make install
+rm -f %{buildroot}/usr/share/doc/AvroC/index.html
 
 %clean
 rm -rf %{buildroot}

--- a/rpm/avro-c.spec
+++ b/rpm/avro-c.spec
@@ -1,0 +1,118 @@
+Name:    avro-c
+Version: %{__version}
+Release: %{__release}%{?dist}
+
+Summary: Apache Avro data serialization C library
+Group:   Development/Libraries/C and C++
+License: ASL 2.0
+URL:     http://avro.apache.org
+Source:	 avro-c-%{version}.tar.gz
+
+Patch0: 0001-Use-GNUInstallDirs-for-proper-install-locations.patch
+
+BuildRequires: cmake zlib-devel snappy-devel jansson-devel
+# lzma-devel not available on fc20
+#BuildRequires: lzma-devel
+BuildRoot: %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
+
+# Something odd happens with AutoReq.
+# snappy-devel provides 'pkgconfig(snappy)', but for some reason
+# AutoReq picks up 'pkgconfig(libsnappy)' so we insert a hack here
+# to change it to the right Req
+%filter_from_requires s/pkgconfig(libsnappy)/pkgconfig(snappy)/g
+# After defining the filter, we need to call this to set it up
+%filter_setup
+
+%description
+Apache Avro™ is a data serialization system.
+Avro provides:
+ * Rich data structures.
+ * A compact, fast, binary data format.
+ * A container file, to store persistent data.
+ * Remote procedure call (RPC).
+ * Simple integration with dynamic languages.
+
+%package devel
+Summary: Apache Avro data serialization C library (Development Environment)
+Group:   Development/Libraries/C and C++
+Requires: %{name} = %{version}
+
+%description devel
+Apache Avro™ is a data serialization system.
+Avro provides:
+ * Rich data structures.
+ * A compact, fast, binary data format.
+ * A container file, to store persistent data.
+ * Remote procedure call (RPC).
+ * Simple integration with dynamic languages.
+
+This package contains headers and libraries required to build applications
+using avro-c.
+
+
+%package tools
+Summary: Apache Avro data serialization C library (Tools)
+Group:   Development/Libraries/C and C++
+Requires: %{name} = %{version}
+
+%description tools
+Apache Avro™ is a data serialization system.
+Avro provides:
+ * Rich data structures.
+ * A compact, fast, binary data format.
+ * A container file, to store persistent data.
+ * Remote procedure call (RPC).
+ * Simple integration with dynamic languages.
+
+This package contains Avro tools using avro-c.
+
+
+
+%prep
+%setup -q -n %{name}-%{version}
+
+%patch0 -p1
+
+%build
+%cmake .
+make %{?_smp_mflags}
+
+%install
+rm -rf %{buildroot}
+DESTDIR=%{buildroot} make install
+
+%clean
+rm -rf %{buildroot}
+
+%post   -p /sbin/ldconfig
+%postun -p /sbin/ldconfig
+
+%files
+%defattr(444,root,root)
+%{_libdir}/libavro.so.*
+%defattr(-,root,root)
+%doc LICENSE
+
+
+%files devel
+%defattr(-,root,root)
+%{_includedir}/avro.h
+%{_includedir}/avro
+%defattr(444,root,root)
+%{_libdir}/libavro.a
+%{_libdir}/libavro.so
+%{_libdir}/pkgconfig/avro-c.pc
+%doc LICENSE docs/index.txt
+
+
+%files tools
+%defattr(755,root,root)
+%{_bindir}/avroappend
+%{_bindir}/avrocat
+%{_bindir}/avromod
+%{_bindir}/avropipe
+%doc LICENSE
+
+%changelog
+* Mon May 16 2016 Magnus Edenhill <magnus@confluent.io> 1.8.0-0
+- Initial RPM


### PR DESCRIPTION
Purpose: Confluent Clinets Eng Independent Release Builder/Job

Changes:
* Collapse rpm branch into master
* Symlink SOURCES/0001-Use-GNUInstallDirs-for-proper-install-locations.patch to debian/patches/0001-Use-GNUInstallDirs-for-proper-install-locations.patch

Testing these changes in packaging here:
* https://github.com/confluentinc/packaging/pull/930
* https://github.com/confluentinc/packaging/pull/931